### PR TITLE
[wip] Gmail から特定のメールの件名と本文を抜き出してまとめてくれる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Gemfile.lock
 *.rdb
 client_secret.json
+
+lita_config.rb

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /vendor/bundle
 
 Gemfile.lock
+*.rdb
+client_secret.json

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'lita-cron'
 gem 'json'
 
 gem "lita-chat", path: "handlers/lita-chat"
+gem "lita-gmail", path: "handlers/lita-gmail"
+
+gem 'google-api-client'
 
 group :production do
   gem "io-console"

--- a/handlers/lita-gmail/.gitignore
+++ b/handlers/lita-gmail/.gitignore
@@ -1,0 +1,17 @@
+*.gem
+*.rbc
+.bundle
+.config
+.yardoc
+Gemfile.lock
+InstalledFiles
+_yardoc
+coverage
+doc/
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/handlers/lita-gmail/.gitignore
+++ b/handlers/lita-gmail/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/vendor/bundle

--- a/handlers/lita-gmail/Gemfile
+++ b/handlers/lita-gmail/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/handlers/lita-gmail/Gemfile
+++ b/handlers/lita-gmail/Gemfile
@@ -3,3 +3,10 @@ source "https://rubygems.org"
 gemspec
 
 gem 'google-api-client'
+
+group :development, :test do
+  gem 'pry'
+  gem 'pry-doc'
+  gem 'pry-byebug'
+  gem 'pry-stack_explorer'
+end

--- a/handlers/lita-gmail/Gemfile
+++ b/handlers/lita-gmail/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem 'google-api-client'

--- a/handlers/lita-gmail/README.md
+++ b/handlers/lita-gmail/README.md
@@ -1,0 +1,19 @@
+# lita-gmail
+
+TODO: Add a description of the plugin.
+
+## Installation
+
+Add lita-gmail to your Lita instance's Gemfile:
+
+``` ruby
+gem "lita-gmail"
+```
+
+## Configuration
+
+TODO: Describe any configuration attributes the plugin exposes.
+
+## Usage
+
+TODO: Describe the plugin's features and how to use them.

--- a/handlers/lita-gmail/Rakefile
+++ b/handlers/lita-gmail/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/handlers/lita-gmail/lib/lita-gmail.rb
+++ b/handlers/lita-gmail/lib/lita-gmail.rb
@@ -1,0 +1,12 @@
+require "lita"
+
+Lita.load_locales Dir[File.expand_path(
+  File.join("..", "..", "locales", "*.yml"), __FILE__
+)]
+
+require "lita/handlers/gmail"
+
+Lita::Handlers::Gmail.template_root File.expand_path(
+  File.join("..", "..", "templates"),
+ __FILE__
+)

--- a/handlers/lita-gmail/lib/lita/handlers/gmail.rb
+++ b/handlers/lita-gmail/lib/lita/handlers/gmail.rb
@@ -1,7 +1,57 @@
+require 'google/apis/gmail_v1'
+require 'googleauth'
+require 'googleauth/stores/file_token_store'
+
+require 'fileutils'
+
 module Lita
   module Handlers
     class Gmail < Handler
-      # insert handler code here
+      route(/get mail/i, :mail)
+
+      OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+      APPLICATION_NAME = 'Gmail API Ruby Quickstart'
+      CLIENT_SECRETS_PATH = 'client_secret.json'
+      CREDENTIALS_PATH = File.join(Dir.home, '.credentials',
+                                   "gmail-ruby-quickstart.yaml")
+      SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
+
+      def authorize(response)
+        FileUtils.mkdir_p(File.dirname(CREDENTIALS_PATH))
+
+        client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
+        token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+        authorizer = Google::Auth::UserAuthorizer.new(
+          client_id, SCOPE, token_store)
+        user_id = 'default'
+        credentials = authorizer.get_credentials(user_id)
+        if credentials.nil?
+          url = authorizer.get_authorization_url(
+            base_url: OOB_URI)
+          response.reply "Open the following URL in the browser and enter the " +
+               "resulting code after authorization"
+          response.reply url
+          code = gets
+          credentials = authorizer.get_and_store_credentials_from_code(
+            user_id: user_id, code: code, base_url: OOB_URI)
+        end
+        credentials
+      end
+
+      def mail(response)
+        # Initialize the API
+        service = Google::Apis::GmailV1::GmailService.new
+        service.client_options.application_name = APPLICATION_NAME
+        service.authorization = authorize(response)
+
+        # Show the user's labels
+        user_id = 'me'
+        result = service.list_user_labels(user_id)
+
+        response.reply "Labels:"
+        response.reply "No labels found" if result.labels.empty?
+        result.labels.each { |label| response.reply "- #{label.name}" }
+      end
 
       Lita.register_handler(self)
     end

--- a/handlers/lita-gmail/lib/lita/handlers/gmail.rb
+++ b/handlers/lita-gmail/lib/lita/handlers/gmail.rb
@@ -1,0 +1,9 @@
+module Lita
+  module Handlers
+    class Gmail < Handler
+      # insert handler code here
+
+      Lita.register_handler(self)
+    end
+  end
+end

--- a/handlers/lita-gmail/lita-gmail.gemspec
+++ b/handlers/lita-gmail/lita-gmail.gemspec
@@ -3,10 +3,10 @@ Gem::Specification.new do |spec|
   spec.version       = "0.1.0"
   spec.authors       = ["Shoma SATO"]
   spec.email         = ["noir.neo.04@gmail.com"]
-  spec.description   = "TODO: Add a description"
-  spec.summary       = "TODO: Add a summary"
-  spec.homepage      = "TODO: Add a homepage"
-  spec.license       = "TODO: Add a license"
+  spec.description   = ""
+  spec.summary       = ""
+  spec.homepage      = ""
+  spec.license       = ""
   spec.metadata      = { "lita_plugin_type" => "handler" }
 
   spec.files         = `git ls-files`.split($/)

--- a/handlers/lita-gmail/lita-gmail.gemspec
+++ b/handlers/lita-gmail/lita-gmail.gemspec
@@ -1,0 +1,24 @@
+Gem::Specification.new do |spec|
+  spec.name          = "lita-gmail"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Shoma SATO"]
+  spec.email         = ["noir.neo.04@gmail.com"]
+  spec.description   = "TODO: Add a description"
+  spec.summary       = "TODO: Add a summary"
+  spec.homepage      = "TODO: Add a homepage"
+  spec.license       = "TODO: Add a license"
+  spec.metadata      = { "lita_plugin_type" => "handler" }
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "lita", ">= 4.6"
+
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "rspec", ">= 3.0.0"
+end

--- a/handlers/lita-gmail/locales/en.yml
+++ b/handlers/lita-gmail/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  lita:
+    handlers:
+      gmail:

--- a/handlers/lita-gmail/spec/lita/handlers/gmail_spec.rb
+++ b/handlers/lita-gmail/spec/lita/handlers/gmail_spec.rb
@@ -1,0 +1,4 @@
+require "spec_helper"
+
+describe Lita::Handlers::Gmail, lita_handler: true do
+end

--- a/handlers/lita-gmail/spec/lita/handlers/gmail_spec.rb
+++ b/handlers/lita-gmail/spec/lita/handlers/gmail_spec.rb
@@ -1,4 +1,11 @@
 require "spec_helper"
 
 describe Lita::Handlers::Gmail, lita_handler: true do
+  it { is_expected.to route('mail') }
+  it { is_expected.to route('mail').to(:mail) }
+
+  it '#mail' do
+    send_message('mail')
+    expect(replies.last).not_to eq("")
+  end
 end

--- a/handlers/lita-gmail/spec/lita/handlers/gmail_spec.rb
+++ b/handlers/lita-gmail/spec/lita/handlers/gmail_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
 describe Lita::Handlers::Gmail, lita_handler: true do
-  it { is_expected.to route('mail') }
-  it { is_expected.to route('mail').to(:mail) }
+  it { is_expected.to route('kintai') }
+  it { is_expected.to route('kintai').to(:kintai) }
 
-  it '#mail' do
-    send_message('mail')
+  it '#kintai' do
+    send_message('kintai')
     expect(replies.last).not_to eq("")
   end
 end

--- a/handlers/lita-gmail/spec/spec_helper.rb
+++ b/handlers/lita-gmail/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require "lita-gmail"
+require "lita/rspec"
+
+# A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
+# was generated with Lita 4, the compatibility mode should be left disabled.
+Lita.version_3_compatibility_mode = false

--- a/lita_config.rb.example
+++ b/lita_config.rb.example
@@ -29,8 +29,6 @@ Lita.configure do |config|
   ## Example: Set options for the Redis connection.
   # config.redis.host = "127.0.0.1"
   # config.redis.port = 1234
-  
-  config.http.port = 8081
 
   ## Example: Set configuration for any loaded handlers. See the handler's
   ## documentation for options.


### PR DESCRIPTION
Gmail にアクセスして、特定のメールを抜き出せるようにする。
- [x] あるラベルがついた今日のメールを抜き出す
- [x] 抜き出したメールの件名と本文をまとめて返す
- [x] 前後に定型文を入れる
- [ ] アドレスだけ抜いて名前は返したい
- [ ] 今日だけ、のクエリがなんかうまくいかないのでどうにかする
- [ ] auth の流れを整理
