### PR TITLE
:green_heart: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM litaio/lita
+MAINTAINER Shoma SATO <noir.neo.04@gmail.com>
+
+RUN apt-get update \
+    && apt-get install -y git libssl-dev \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
だいたいこんな感じで動いてくれる

```
docker stop lita && docker rm lita
docker build -t noir-neo/neobot2 .
docker run -d --name lita --link redis --restart always -v /path/to/docker_bundle_cache:/var/bundle -p 8001:8001 noir-neo/neobot2
```

`path/to/docker_bundle_cache` 設定しなくても動くけど毎回 bundle install がフルで走っちゃうっぽい？？
`./*` を設定するとなんか build できなくなるような気がしたので、 `../*` あたりに(フルパス書けって言われてた気もする)

ポートの指定はとりあえず lita_config のと合わせておけばOK
